### PR TITLE
refactor: deduplicate and split models

### DIFF
--- a/src/frontend/src/app/components/admin-appointments/admin-appointments.component.ts
+++ b/src/frontend/src/app/components/admin-appointments/admin-appointments.component.ts
@@ -5,15 +5,15 @@ import { Router } from '@angular/router';
 import { AppointmentService } from '../../services/appointment.service';
 import { AuthService } from '../../services/auth.service';
 import { ServiceManagementService } from '../../services/service-management.service';
-import { 
-  Appointment, 
-  AppointmentsByDateResponse, 
-  AppointmentHistoryResponse, 
-  Service,
+import {
+  Appointment,
+  AppointmentsByDateResponse,
+  AppointmentHistoryResponse,
   CreateAppointmentRequest,
   Client,
   EarliestAppointmentDateResponse
 } from '../../models/api-models';
+import { Service } from '../../models/services.models';
 
 @Component({
   selector: 'app-admin-appointments',

--- a/src/frontend/src/app/components/admin-categories/admin-categories.component.ts
+++ b/src/frontend/src/app/components/admin-categories/admin-categories.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { CategoryManagementService } from '../../services/category-management.service';
 import { ServiceManagementService } from '../../services/service-management.service';
-import { Category, CreateCategoryRequest, UpdateCategoryRequest, CategoryServiceCount } from '../../models/api-models';
+import { Category, CreateCategoryRequest, UpdateCategoryRequest, CategoryServiceCount } from '../../models/services.models';
 
 @Component({
   selector: 'app-admin-categories',

--- a/src/frontend/src/app/components/admin-gallery/admin-gallery.component.ts
+++ b/src/frontend/src/app/components/admin-gallery/admin-gallery.component.ts
@@ -4,14 +4,14 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ApiService } from '../../services/api.service';
 import { AuthService } from '../../services/auth.service';
-import { 
-  GalleryImage, 
-  GalleryImageResponse, 
-  CreateGalleryImageRequest, 
+import {
+  GalleryImage,
+  GalleryImageResponse,
+  CreateGalleryImageRequest,
   UpdateGalleryImageRequest,
   GalleryCategory,
   UploadImageResponse
-} from '../../models/api-models';
+} from '../../models/gallery.models';
 
 @Component({
   selector: 'app-admin-gallery',

--- a/src/frontend/src/app/components/admin-services/admin-services.component.ts
+++ b/src/frontend/src/app/components/admin-services/admin-services.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { ServiceManagementService } from '../../services/service-management.service';
 import { ApiService } from '../../services/api.service';
-import { Service, Category, CreateServiceRequest, UpdateServiceRequest } from '../../models/api-models';
+import { Service, Category, CreateServiceRequest, UpdateServiceRequest } from '../../models/services.models';
 
 @Component({
   selector: 'app-admin-services',

--- a/src/frontend/src/app/components/aftercare/aftercare.component.ts
+++ b/src/frontend/src/app/components/aftercare/aftercare.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { ServiceManagementService } from '../../services/service-management.service';
-import { Service } from '../../models/api-models';
+import { Service } from '../../models/services.models';
 
 @Component({
   selector: 'app-aftercare',

--- a/src/frontend/src/app/components/booking/booking.component.ts
+++ b/src/frontend/src/app/components/booking/booking.component.ts
@@ -4,7 +4,8 @@ import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AppointmentService } from '../../services/appointment.service';
 import { ServiceManagementService } from '../../services/service-management.service';
-import { Service, CreateAppointmentRequest } from '../../models/api-models';
+import { Service } from '../../models/services.models';
+import { CreateAppointmentRequest } from '../../models/api-models';
 
 @Component({
   selector: 'app-booking',

--- a/src/frontend/src/app/components/gallery/gallery.component.ts
+++ b/src/frontend/src/app/components/gallery/gallery.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { ApiService } from '../../services/api.service';
-import { GalleryImage } from '../../models/api-models';
+import { GalleryImage } from '../../models/gallery.models';
 
 interface Category {
   id: string;

--- a/src/frontend/src/app/components/services/services.component.ts
+++ b/src/frontend/src/app/components/services/services.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ServiceManagementService } from '../../services/service-management.service';
-import { Service, Category } from '../../models/api-models';
+import { Service, Category } from '../../models/services.models';
 
 interface ServiceCategory {
   id: number;

--- a/src/frontend/src/app/models/api-models.ts
+++ b/src/frontend/src/app/models/api-models.ts
@@ -1,3 +1,5 @@
+import { Service } from './services.models';
+
 // Common models shared between frontend and backend
 
 export interface ApiResponse<T> {
@@ -32,51 +34,6 @@ export interface Client {
   lastName: string;
   email: string;
   phoneNumber: string;
-}
-
-export interface Category {
-  id: number;
-  name: string;
-}
-
-export interface CategoryServiceCount {
-  categoryId: number;
-  categoryName: string;
-  serviceCount: number;
-}
-
-export interface Service {
-  id: number;
-  name: string;
-  description: string;
-  price?: number;
-  duration?: number;
-  appointmentBufferTime?: number;
-  category: Category;
-  website?: string;
-  afterCareInstructions?: string;
-}
-
-export interface CreateServiceRequest {
-  name: string;
-  description?: string;
-  afterCareInstructions?: string;
-  price?: number;
-  duration?: number;
-  appointmentBufferTime?: number;
-  categoryId: number;
-  website?: string;
-}
-
-export interface UpdateServiceRequest {
-  name?: string;
-  description?: string;
-  afterCareInstructions?: string | null;
-  price?: number;
-  duration?: number;
-  appointmentBufferTime?: number;
-  categoryId?: number;
-  website?: string;
 }
 
 export interface CreateAppointmentRequest {
@@ -215,99 +172,4 @@ export interface ClientBanResponse {
   success: boolean;
   message: string;
   unbannedFlags?: number;
-}
-
-// Service Management interfaces for admin panel
-export interface CreateServiceRequest {
-  name: string;
-  description?: string;
-  price?: number;
-  duration?: number;
-  appointmentBufferTime?: number;
-  categoryId: number;
-  website?: string;
-}
-
-export interface UpdateServiceRequest {
-  name?: string;
-  description?: string;
-  price?: number;
-  duration?: number;
-  appointmentBufferTime?: number;
-  categoryId?: number;
-  website?: string;
-}
-
-// Gallery Management interfaces for admin panel
-export interface GalleryImage {
-  id: number;
-  src: string;
-  alt: string;
-  category: string;
-  title?: string;
-  description?: string;
-  isActive: boolean;
-  sortOrder: number;
-  uploadedAt: string;
-  updatedAt?: string;
-}
-
-export interface CreateGalleryImageRequest {
-  src: string;
-  alt: string;
-  category: string;
-  title?: string;
-  description?: string;
-  isActive?: boolean;
-  sortOrder?: number;
-}
-
-export interface UpdateGalleryImageRequest {
-  src?: string;
-  alt?: string;
-  category?: string;
-  title?: string;
-  description?: string;
-  isActive?: boolean;
-  sortOrder?: number;
-}
-
-export interface GalleryImageResponse {
-  success: boolean;
-  data: GalleryImage[];
-  totalCount: number;
-  categories: string[];
-}
-
-export interface GalleryCategory {
-  id: string;
-  name: string;
-  count: number;
-}
-
-export interface UploadImageResponse {
-  success: boolean;
-  url: string;
-  filename: string;
-  message?: string;
-}
-
-// Category Management interfaces for admin panel
-export interface CreateCategoryRequest {
-  name: string;
-}
-
-export interface UpdateCategoryRequest {
-  name: string;
-}
-
-export interface CategoryResponse {
-  success: boolean;
-  data: Category;
-  message?: string;
-}
-
-export interface DeleteCategoryResponse {
-  success: boolean;
-  message: string;
 }

--- a/src/frontend/src/app/models/gallery.models.ts
+++ b/src/frontend/src/app/models/gallery.models.ts
@@ -1,0 +1,52 @@
+export interface GalleryImage {
+  id: number;
+  src: string;
+  alt: string;
+  category: string;
+  title?: string;
+  description?: string;
+  isActive: boolean;
+  sortOrder: number;
+  uploadedAt: string;
+  updatedAt?: string;
+}
+
+export interface CreateGalleryImageRequest {
+  src: string;
+  alt: string;
+  category: string;
+  title?: string;
+  description?: string;
+  isActive?: boolean;
+  sortOrder?: number;
+}
+
+export interface UpdateGalleryImageRequest {
+  src?: string;
+  alt?: string;
+  category?: string;
+  title?: string;
+  description?: string;
+  isActive?: boolean;
+  sortOrder?: number;
+}
+
+export interface GalleryImageResponse {
+  success: boolean;
+  data: GalleryImage[];
+  totalCount: number;
+  categories: string[];
+}
+
+export interface GalleryCategory {
+  id: string;
+  name: string;
+  count: number;
+}
+
+export interface UploadImageResponse {
+  success: boolean;
+  url: string;
+  filename: string;
+  message?: string;
+}

--- a/src/frontend/src/app/models/services.models.ts
+++ b/src/frontend/src/app/models/services.models.ts
@@ -1,0 +1,63 @@
+export interface Category {
+  id: number;
+  name: string;
+}
+
+export interface CategoryServiceCount {
+  categoryId: number;
+  categoryName: string;
+  serviceCount: number;
+}
+
+export interface Service {
+  id: number;
+  name: string;
+  description: string;
+  price?: number;
+  duration?: number;
+  appointmentBufferTime?: number;
+  category: Category;
+  website?: string;
+  afterCareInstructions?: string;
+}
+
+export interface CreateServiceRequest {
+  name: string;
+  description?: string;
+  afterCareInstructions?: string;
+  price?: number;
+  duration?: number;
+  appointmentBufferTime?: number;
+  categoryId: number;
+  website?: string;
+}
+
+export interface UpdateServiceRequest {
+  name?: string;
+  description?: string;
+  afterCareInstructions?: string | null;
+  price?: number;
+  duration?: number;
+  appointmentBufferTime?: number;
+  categoryId?: number;
+  website?: string;
+}
+
+export interface CreateCategoryRequest {
+  name: string;
+}
+
+export interface UpdateCategoryRequest {
+  name: string;
+}
+
+export interface CategoryResponse {
+  success: boolean;
+  data: Category;
+  message?: string;
+}
+
+export interface DeleteCategoryResponse {
+  success: boolean;
+  message: string;
+}

--- a/src/frontend/src/app/services/api.service.ts
+++ b/src/frontend/src/app/services/api.service.ts
@@ -2,13 +2,11 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
 import { environment } from '../../environments/environment';
-import { 
-  ApiResponse, 
-  AuthRequest, 
-  AuthResponse, 
+import {
+  ApiResponse,
+  AuthRequest,
+  AuthResponse,
   User,
-  Service,
-  Category,
   CreateAppointmentRequest,
   Appointment,
   AppointmentHistoryResponse,
@@ -21,19 +19,27 @@ import {
   ClientReviewFlag,
   UpdateReviewFlagRequest,
   BanClientRequest,
-  ClientBanResponse,
+  ClientBanResponse
+} from '../models/api-models';
+
+import {
+  Service,
+  Category,
   CreateServiceRequest,
   UpdateServiceRequest,
   CreateCategoryRequest,
   UpdateCategoryRequest,
-  CategoryServiceCount,
+  CategoryServiceCount
+} from '../models/services.models';
+
+import {
   GalleryImageResponse,
   GalleryImage,
   CreateGalleryImageRequest,
   UpdateGalleryImageRequest,
   UploadImageResponse,
   GalleryCategory
-} from '../models/api-models';
+} from '../models/gallery.models';
 
 @Injectable({
   providedIn: 'root'

--- a/src/frontend/src/app/services/category-management.service.ts
+++ b/src/frontend/src/app/services/category-management.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, BehaviorSubject, map, catchError, tap } from 'rxjs';
 import { ApiService } from './api.service';
-import { Category, CreateCategoryRequest, UpdateCategoryRequest, CategoryServiceCount } from '../models/api-models';
+import { Category, CreateCategoryRequest, UpdateCategoryRequest, CategoryServiceCount } from '../models/services.models';
 
 @Injectable({
   providedIn: 'root'

--- a/src/frontend/src/app/services/service-management.service.ts
+++ b/src/frontend/src/app/services/service-management.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, BehaviorSubject, tap } from 'rxjs';
 import { ApiService } from './api.service';
-import { Service, Category } from '../models/api-models';
+import { Service, Category } from '../models/services.models';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
## Summary
- remove duplicate service request models
- split service and gallery models into dedicated modules
- update imports for new model modules

## Testing
- `cd src/frontend && npm run build -- --configuration development`

------
https://chatgpt.com/codex/tasks/task_e_6899ec1b6c608323b1622f70e1f27ef2